### PR TITLE
Fix double slash in route URL

### DIFF
--- a/.upsun/config.yaml
+++ b/.upsun/config.yaml
@@ -45,7 +45,7 @@ applications:
         set -e
         echo "Deploy writable config..."
         cp manifest.json config/manifest.json
-        export ROUTE_PLUGINAPP=$(echo $PLATFORM_ROUTES | base64 -d | jq -r 'to_entries[] | select(.value.primary == true) | .value.production_url')
+        export ROUTE_PLUGINAPP=$(echo $PLATFORM_ROUTES | base64 -d | jq -r 'to_entries[] | select(.value.primary == true) | .value.production_url | rtrimstr("/")')
         sed -i "s|http://localhost:8080|${ROUTE_PLUGINAPP}|g" config/manifest.json
 
 routes:


### PR DESCRIPTION
Remove trailing slash from the production URL to prevent double slashes in the route configuration.