### PR TITLE
fix(auth): handle invalid/rotated Fastly token with user-friendly message

### DIFF
--- a/src/components/SetupCard.vue
+++ b/src/components/SetupCard.vue
@@ -3,9 +3,15 @@ import { ref } from 'vue';
 import Card from 'primevue/card';
 import Button from 'primevue/button';
 import InputText from 'primevue/inputtext';
+import Message from 'primevue/message';
 import ApiCache from '@/stores/localStorage';
 
 const apiStorage = new ApiCache();
+// Read directly from sessionStorage at setup time — synchronous, no timing issues.
+// sessionStorage is written by setLogoutReason() before logout() clears credentials,
+// so it is always available when this component mounts after a 401.
+const logoutReason = ref(apiStorage.getLogoutReason());
+console.log('FastSun > SetupCard mounted, logoutReason:', logoutReason.value);
 const props = defineProps({
   service_id: {
     type: String,
@@ -43,6 +49,8 @@ function saveId() {
   if (fastly_id.value && fastly_token.value) {
     console.log('FastSun > Set ID & Token for project:', props.project_id, 'environment:', props.environment_id);
     apiStorage.setFastlyCredentials(props.project_id, props.environment_id, fastly_id.value, fastly_token.value);
+    apiStorage.clearLogoutReason();
+    logoutReason.value = '';
 
     // Emit the saved credentials to parent component
     emit('credentials:saved', {
@@ -60,8 +68,13 @@ function saveId() {
   <Card>
     <template #title>Setup Fastly Credentials</template>
     <template #content>
+      <Message v-if="logoutReason" severity="warn" :closable="false" class="mb-4">
+        {{ logoutReason }}
+      </Message>
+
       <div class="setupcard-explanation text-sm text-gray-700">
-        Your Fastly credentials are stored securely within your browser and solely transmitted to https://fastsun.plugins.pltfrm.sh/ hosted on Upsun.<br />
+        Your Fastly credentials are stored securely within your browser and solely transmitted to
+        https://fastsun.plugins.pltfrm.sh/ hosted on Upsun.<br />
         This method enhances security by ensuring that your credentials are not shared with any third parties, thereby
         reducing the risk of unauthorized access.<br />
         Please note that if you access Upsun from a different browser or device, you will be required to re-enter your

--- a/src/layout/AppTopbar.vue
+++ b/src/layout/AppTopbar.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-// const { toggleMenu, toggleDarkMode, isDarkTheme } = useLayout();
 function toggleMenu() {}
 </script>
 
@@ -44,20 +43,7 @@ function toggleMenu() {}
       </div>
 
       <div class="layout-topbar-menu hidden lg:block">
-        <div class="layout-topbar-menu-content">
-          <button type="button" class="layout-topbar-action">
-            <i class="pi pi-calendar"></i>
-            <span>Calendar</span>
-          </button>
-          <button type="button" class="layout-topbar-action">
-            <i class="pi pi-inbox"></i>
-            <span>Messages</span>
-          </button>
-          <button type="button" class="layout-topbar-action">
-            <i class="pi pi-user"></i>
-            <span>Profile</span>
-          </button>
-        </div>
+        <div class="layout-topbar-menu-content"></div>
       </div>
     </nav>
   </div>

--- a/src/services/secureApiService.ts
+++ b/src/services/secureApiService.ts
@@ -52,6 +52,14 @@ class SecureApiService {
     });
 
     if (!response.ok) {
+      if (response.status === 401) {
+        const credentialsStore = useCredentialsStore();
+        credentialsStore.setLogoutReason(
+          'Your Fastly token is no longer valid (401). It may have been rotated or revoked. Please update your credentials.',
+        );
+        credentialsStore.logout();
+        throw new Error('Authentication failed: your Fastly token is invalid or has been rotated. Please update your credentials.');
+      }
       throw new Error(`API request failed: ${response.status} ${response.statusText}`);
     }
 

--- a/src/stores/credentialsStore.ts
+++ b/src/stores/credentialsStore.ts
@@ -10,6 +10,8 @@ class CredentialsStore {
   private _projectId = ref<string>('');
   private _environmentId = ref<string>('');
   private _vclVersion = ref<number>(-1);
+  // Initialized from sessionStorage so the value is ready before any component mounts
+  private _logoutReason = ref<string>(sessionStorage.getItem('fastcdn-logout-reason') ?? '');
 
   private localStore = new LocalStore();
 
@@ -55,6 +57,18 @@ class CredentialsStore {
     if (credentials) {
       this._serviceId.value = credentials.fastlyId;
       this._serviceToken.value = credentials.fastlyToken;
+
+      // serviceId loaded but token is empty (failed to decrypt or corrupted).
+      // No API call will be made so no 401 will be caught — set the reason here directly.
+      if (credentials.fastlyId && !credentials.fastlyToken) {
+        console.warn('FastSun > loadCredentials: serviceId present but token empty after decrypt');
+        this.setLogoutReason(
+          'Your Fastly token could not be loaded (possibly after a key rotation or browser migration). Please re-enter your credentials.',
+        );
+      } else if (credentials.fastlyId && credentials.fastlyToken) {
+        // Credentials loaded successfully — clear any previous reason
+        this.clearLogoutReason();
+      }
     } else {
       this._serviceId.value = '';
       this._serviceToken.value = '';
@@ -69,13 +83,32 @@ class CredentialsStore {
         this._serviceId.value,
         this._serviceToken.value,
       );
+      this.clearLogoutReason();
     }
   }
-
   clearCredentials() {
     this._serviceId.value = '';
     this._serviceToken.value = '';
     this._vclVersion.value = -1;
+  }
+
+  logout() {
+    this.localStore.resetFastly(this._projectId.value, this._environmentId.value);
+    this.clearCredentials();
+  }
+
+  setLogoutReason(reason: string) {
+    this._logoutReason.value = reason;
+    this.localStore.setLogoutReason(reason);
+  }
+
+  getLogoutReason(): string {
+    return this._logoutReason.value;
+  }
+
+  clearLogoutReason() {
+    this._logoutReason.value = '';
+    this.localStore.clearLogoutReason();
   }
 
   // Safe getters that don't expose the actual tokens

--- a/src/stores/localStorage.ts
+++ b/src/stores/localStorage.ts
@@ -12,6 +12,7 @@ const KEY_FASTLY_TK = 'fastcdn-fastly-api-tk'; // Legacy key - kept for migratio
 const KEY_ADMIN_MODE = 'fastcdn-admin-mode';
 const KEY_RTAPI_ENABLE = 'fastcdn-rtapi-enable';
 const KEY_SCHEMA_VERSION = 'fastcdn-schema-version';
+const KEY_LOGOUT_REASON = 'fastcdn-logout-reason'; // sessionStorage — clears on tab close
 
 // Value of encrypt/Decrypt engine.
 const SECRET = import.meta.env.VITE_CRYPTO_SECRET_KEY;
@@ -199,6 +200,20 @@ export default class LocalStore {
     if (credentials) {
       this.setFastlyCredentials('default', 'default', credentials.fastlyId, fastly_token);
     }
+  }
+
+  // ---- Logout reason (sessionStorage — survives page reload, clears on tab close) ----
+
+  setLogoutReason(reason: string) {
+    sessionStorage.setItem(KEY_LOGOUT_REASON, reason);
+  }
+
+  getLogoutReason(): string {
+    return sessionStorage.getItem(KEY_LOGOUT_REASON) ?? '';
+  }
+
+  clearLogoutReason() {
+    sessionStorage.removeItem(KEY_LOGOUT_REASON);
   }
 
   resetFastly(projectId?: string, environmentId?: string) {

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -72,7 +72,25 @@ function refresh() {
       }
     })
     .catch((error) => {
-      toast.add({ severity: 'error', summary: 'Error', detail: error, life: 5000 });
+      // Verbose log so we can trace the error shape in browser devtools
+      console.warn('FastSun > API Error shape:', {
+        status: error?.response?.status,
+        errorStatus: error?.status,
+        message: error?.message,
+        error,
+      });
+
+      const is401 =
+        error?.response?.status === 401 || error?.status === 401 || String(error?.message ?? '').includes('401');
+
+      if (is401) {
+        credentialsStore.setLogoutReason(
+          'Your Fastly token is no longer valid (401). It may have been rotated or revoked. Please update your credentials.',
+        );
+        credentialsStore.logout();
+      } else {
+        toast.add({ severity: 'error', summary: 'Error', detail: error?.message ?? error, life: 5000 });
+      }
     });
 }
 
@@ -249,6 +267,14 @@ const vclVersionIsDefined = computed(() => credentialsStore.vclVersionIsDefined.
           </TabPanel>
         </TabPanels>
       </Tabs>
+    </div>
+
+    <!-- Credentials valid but VCL version not yet loaded (loading after login) -->
+    <div v-else class="loading-container">
+      <div class="loading-content">
+        <ProgressSpinner style="width: 60px; height: 60px" strokeWidth="4" fill="transparent" animationDuration="1s" />
+        <p class="loading-text">Connecting to Fastly...</p>
+      </div>
     </div>
   </main>
 </template>


### PR DESCRIPTION
## Problem

Fixes #36

When the Fastly Service Token is rotated or revoked, the plugin silently redirects to the setup screen with no explanation. The only workaround was to manually clear the browser's localStorage.

## Root cause

Two distinct cases were not handled:

1. **Token rotated while app is running** — the API returns 401, but the error was not caught and no feedback was given to the user
2. **Token empty after decryption** (e.g. after a browser migration or storage corruption) — `serviceIsDefined` is false before any API call is made, so the 401 path is never reached

## Solution

- **`localStorage.ts`**: add `setLogoutReason` / `getLogoutReason` / `clearLogoutReason` backed by `sessionStorage` (survives page reload, cleared on tab close)
- **`credentialsStore.ts`**: initialize `_logoutReason` ref directly from `sessionStorage` at module load time (no timing issues); detect empty token in `loadCredentials()` and set reason immediately
- **`HomeView.vue`**: detect 401 in `refresh().catch()`, call `setLogoutReason()` + `logout()` before Vue re-renders
- **`SetupCard.vue`**: read `logoutReason` synchronously at `<script setup>` time via `ref(apiStorage.getLogoutReason())`, display a warning `<Message>` banner

## Cleanup

- Removed dead `CREDENTIALS_INVALID` eventBus event and its listeners (previous approach that failed on page reload)
- Cleaned up `AppTopbar.vue` (logout button removed, topbar remains commented out in layout)